### PR TITLE
Peg rtoml to version 0.9.X which works on Windows64 also

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python3 -m pip install pytest PyYAML rtoml
+        python3 -m pip install pytest PyYAML rtoml==0.9.0
 
     - name: Clone dependency repos
       run: |

--- a/doc/release_notes/5.1.3.rst
+++ b/doc/release_notes/5.1.3.rst
@@ -1,0 +1,3 @@
+Fixes
+
+* Peg ``rtoml`` dependency package to 0.9.X so that pip install works on 64-bit Windows.

--- a/doc/release_notes/unreleased.rst
+++ b/doc/release_notes/unreleased.rst
@@ -1,1 +1,3 @@
-Nothing here yet.
+Fixes
+
+* Peg ``rtoml`` dependency package to 0.9.X so that pip install works on 64-bit Windows.

--- a/doc/release_notes/unreleased.rst
+++ b/doc/release_notes/unreleased.rst
@@ -1,3 +1,1 @@
-Fixes
-
-* Peg ``rtoml`` dependency package to 0.9.X so that pip install works on 64-bit Windows.
+Nothing here yet.

--- a/hdl_registers/__init__.py
+++ b/hdl_registers/__init__.py
@@ -21,5 +21,5 @@ HDL_REGISTERS_GENERATED = REPO_ROOT / "generated"
 HDL_REGISTERS_TESTS = REPO_ROOT / "tests"
 HDL_REGISTERS_TOOLS = REPO_ROOT / "tools"
 
-__version__ = "5.1.3"
+__version__ = "5.1.4-dev"
 __doc__ = get_short_slogan()  # pylint: disable=redefined-builtin

--- a/hdl_registers/__init__.py
+++ b/hdl_registers/__init__.py
@@ -21,5 +21,5 @@ HDL_REGISTERS_GENERATED = REPO_ROOT / "generated"
 HDL_REGISTERS_TESTS = REPO_ROOT / "tests"
 HDL_REGISTERS_TOOLS = REPO_ROOT / "tools"
 
-__version__ = "5.1.3-dev"
+__version__ = "5.1.3"
 __doc__ = get_short_slogan()  # pylint: disable=redefined-builtin

--- a/hdl_registers/requirements.txt
+++ b/hdl_registers/requirements.txt
@@ -1,4 +1,4 @@
 GitPython
 PyYAML
-rtoml
+rtoml>= 0.9.0, < 0.10.0
 tsfpga>= 12.3.1


### PR DESCRIPTION
Received private bug report that pip install of hdl-registers does not work on Windows. Seems to be related to https://github.com/samuelcolvin/rtoml/issues/74, since rtoml 0.9.0 worked for the reporter.