### PR TITLE
Remove unpegged rtoml from requirements_develop.txt

### DIFF
--- a/hdl_registers/requirements_develop.txt
+++ b/hdl_registers/requirements_develop.txt
@@ -11,7 +11,6 @@ pytest
 pytest-cov
 pytest-xdist
 PyYAML
-rtoml
 setuptools
 sphinx
 sphinx_sitemap


### PR DESCRIPTION
Mention it only in one place (requirements.txt)