### PR TITLE
Use consistent TOML formatting in documentation examples

### DIFF
--- a/doc/sphinx/rst/field/toml/field_bit.toml
+++ b/doc/sphinx/rst/field/toml/field_bit.toml
@@ -4,23 +4,19 @@ mode = "r_w"
 description = "Configuration register."
 
 # This will allocate a bit field named "enable" in the "config" register.
-[config.enable]
-
 # The "type" property MUST be present and set to "bit".
-type = "bit"
+enable.type = "bit"
 
 # The "description" property is OPTIONAL for a bit field.
 # Will default to "" if not specified.
 # The value specified MUST be a string.
-description = "Enable data passthrough."
+enable.description = "Enable data passthrough."
 
 # The "default_value" property is OPTIONAL for a bit field.
 # Will default to "0" if not specified.
 # The value specified MUST be a string, consisting of either a "1" or a "0".
-default_value = "1"
+enable.default_value = "1"
 
 
-[config.invert]
-
-type = "bit"
-description = "Optionally enable inversion of data."
+invert.type = "bit"
+invert.description = "Optionally enable inversion of data."

--- a/doc/sphinx/rst/field/toml/field_bit_vector.toml
+++ b/doc/sphinx/rst/field/toml/field_bit_vector.toml
@@ -4,30 +4,26 @@ mode = "r_w"
 description = "Configuration register."
 
 # This will allocate a bit vector field named "tuser" in the "config" register.
-[config.tuser]
-
 # The "type" property MUST be present and set to "bit_vector".
-type = "bit_vector"
+tuser.type = "bit_vector"
 
 # The "width" property MUST be present for a bit vector field.
 # The value specified MUST be a positive integer.
-width = 4
+tuser.width = 4
 
 # The "description" property is OPTIONAL for a bit vector field.
 # Will default to "" if not specified.
 # The value specified MUST be a string.
-description = "Value to set for **TUSER** in the data stream."
+tuser.description = "Value to set for **TUSER** in the data stream."
 
 # The "default_value" property is OPTIONAL for a bit vector field.
 # Will default to all zeros if not specified.
 # The value specified MUST be a string whose length is the same as the
 # specified 'width' property value.
 # The value specified MUST contain only ones and zeros.
-default_value = "0101"
+tuser.default_value = "0101"
 
 
-[config.tid]
-
-type = "bit_vector"
-width = 8
-description = "Value to set for **TID** in the data stream."
+tid.type = "bit_vector"
+tid.width = 8
+tid.description = "Value to set for **TID** in the data stream."

--- a/doc/sphinx/rst/field/toml/field_enumeration.toml
+++ b/doc/sphinx/rst/field/toml/field_enumeration.toml
@@ -4,35 +4,30 @@ mode = "r_w"
 description = "Configuration register."
 
 # This will allocate an enumeration field named "severity_level" in the "config" register.
-[config.severity_level]
-
 # The "type" property MUST be present and set to "enumeration".
-type = "enumeration"
+severity_level.type = "enumeration"
 
 # The "description" property is OPTIONAL for an enumeration field.
 # Will default to "" if not specified.
 # The value specified MUST be a string.
-description = "Run-time configuration of severity."
+severity_level.description = "Run-time configuration of severity."
 
 # The "default_value" property is OPTIONAL for an enumeration field.
 # Will default to the first enumeration element declared below, if not specified.
 # The value specified MUST be a string that matches one of the enumeration element names
 # specified below.
-default_value = "warning"
+severity_level.default_value = "warning"
 
 # For an enumeration field there MUST be at least one enumeration element declared.
 # The name of each element is mapped below to the description of that element.
-element.info = "Informational message. Is not considered an error."
-element.warning = "Warning message. Is not considered an error."
-element.error = "Error message. Is considered an error."
-element.failure = "Failure message. Is considered an error."
+severity_level.element.info = "Informational message. Is not considered an error."
+severity_level.element.warning = "Warning message. Is not considered an error."
+severity_level.element.error = "Error message. Is considered an error."
+severity_level.element.failure = "Failure message. Is considered an error."
 
 
-[config.packet_source]
-
-type = "enumeration"
-description = "Set input mux."
-
-element.streaming = "Process incoming streaming data."
-element.dma = "Read packets from DMA."
-element.none = "Don't send anything."
+packet_source.type = "enumeration"
+packet_source.description = "Set input mux."
+packet_source.element.streaming = "Process incoming streaming data."
+packet_source.element.dma = "Read packets from DMA."
+packet_source.element.none = "Don't send anything."

--- a/doc/sphinx/rst/field/toml/field_integer.toml
+++ b/doc/sphinx/rst/field/toml/field_integer.toml
@@ -4,43 +4,37 @@ mode = "r_w"
 description = "Configuration register."
 
 # This will allocate an integer field named "burst_length_bytes" in the "config" register.
-[config.burst_length_bytes]
-
 # The "type" property MUST be present and set to "integer".
-type = "integer"
+burst_length_bytes.type = "integer"
 
 # The "min_value" property is OPTIONAL for an integer field.
 # Will default to 0 if not specified.
 # The value specified MUST be an integer.
-min_value = 1
+burst_length_bytes.min_value = 1
 
 # The "max_value" property MUST be present for an integer field.
 # The value specified MUST be an integer, and greater than or equal to the
 # "min_value" parameter value.
-max_value = 256
+burst_length_bytes.max_value = 256
 
 # The "description" property is OPTIONAL for an integer field.
 # Will default to "" if not specified.
 # The value specified MUST be a string.
-description = "The number of bytes to request."
+burst_length_bytes.description = "The number of bytes to request."
 
 # The "default_value" property is OPTIONAL for a integer field.
 # Will default to the "min_value" parameter value if not specified.
 # The value specified MUST be an integer within the specified min/max range.
-default_value = 64
+burst_length_bytes.default_value = 64
 
 
-[config.increment]
-
-type = "integer"
-min_value = -4
-max_value = 3
-description = "Offset that will be added to data."
-default_value = 0
+increment.type = "integer"
+increment.min_value = -4
+increment.max_value = 3
+increment.description = "Offset that will be added to data."
+increment.default_value = 0
 
 
-[config.retry_count]
-
-type = "integer"
-max_value = 5
-description = "Number of retry attempts before giving up."
+retry_count.type = "integer"
+retry_count.max_value = 5
+retry_count.description = "Number of retry attempts before giving up."

--- a/doc/sphinx/rst/user_guide/toml/toml_format.toml
+++ b/doc/sphinx/rst/user_guide/toml/toml_format.toml
@@ -26,25 +26,20 @@ This is the description of my register.
 Rudimentary RST formatting can be used, such as **boldface** and *italics*.
 """
 
-[config.enable]
+enable.type = "bit"
+enable.description = "Enable operation."
+enable.default_value = "1"
 
-type = "bit"
-description = "Enable operation."
-default_value = "1"
-
-[config.direction]
-
-type = "enumeration"
-description = "Set the data direction."
-default_value = "high_z"
-
-element.data_in = "Receive data from outside the FPGA."
-element.high_z = """
+direction.type = "enumeration"
+direction.description = "Set the data direction."
+direction.default_value = "high_z"
+direction.element.data_in = "Receive data from outside the FPGA."
+direction.element.high_z = """
 Set pins to high impedance.
 
 Will not process any incoming data, nor send anything out.
 """
-element.data_out = "Send data from FPGA."
+direction.element.data_out = "Send data from FPGA."
 
 
 ################################################################################


### PR DESCRIPTION
Closes #195